### PR TITLE
apacheのrewriteが使えるように設定をvhost側に追記

### DIFF
--- a/docker/apache/vhost_stone.conf
+++ b/docker/apache/vhost_stone.conf
@@ -1,11 +1,18 @@
 <VirtualHost *:80>
     DocumentRoot /var/www/html/skymatix/stone/public
     ServerName stone.smx.local
+	ErrorLog logs/access_error_stone_log
+	TransferLog logs/access_stone_log
     ServerSignature Off
     RewriteEngine On
     #RewriteRule ^ https://%{SERVER_NAME}%{REQUEST_URI} [L,QSA,R=permanent]
     #ErrorLog /var/log/httpd/redirect.error.log
     #LogLevel warn
+
+	<Directory "/var/www/html/skymatix/stone/public">
+		Require all granted
+		AllowOverride All
+	</Directory>
 </VirtualHost>
 
 <VirtualHost *:443>
@@ -14,6 +21,13 @@
     ErrorLog logs/ssl_error_stone_log
     TransferLog logs/ssl_access_stone_log
     LogLevel warn
+	ServerSignature Off
+	RewriteEngine On
     SSLCertificateFile /etc/pki/tls/certs/smx.local+1.pem
     SSLCertificateKeyFile /etc/pki/tls/private/smx.local+1-key.pem
+
+    <Directory "/var/www/html/skymatix/stone/public">
+        Require all granted
+        AllowOverride All
+    </Directory>
 </VirtualHost>


### PR DESCRIPTION
- laravelはapacheの場合、rewiteルールを使用するのでVirtualHostの設定に追記
- ついでに80ポートアクセスにログ出力を追記